### PR TITLE
Refactor below proc_macro APIs to use `StyledString`s

### DIFF
--- a/resctl/below/below_derive/src/lib.rs
+++ b/resctl/below/below_derive/src/lib.rs
@@ -88,11 +88,11 @@
 //! * `get_title_pipe(&self) -> String` -- Get all titles in a line, separated by '|', all style applied.
 //! * `get_FIELD_NAME_str(&self) -> String` -- Get the field string, all style applied.
 //! * `get_FIELD_NAME_str_raw(&self) -> String` -- Get the field string, no style applied.
-//! * `get_field_line(&self) -> String` -- Get all fields in a line, all style applied.
+//! * `get_field_line(&self) -> StyledString` -- Get all fields in a line, all style applied.
 //! * `get_csv_field(&self) -> String` -- Get all fields in a line, only apply decorator function. Comma separated.
 //! * `get_csv_title(&self) -> String` -- Get all title in a line, comma separated.
 //! * `cmp_by_FIELD_NAME(left: &Self, right, &Self) -> Ordering` -- comparison function. If field is a link, type of left and right will be Model
-//! * `get_interleave_line(&self, sep: &str, line_sep: &str) -> String` -- Interleave title and value and output
+//! * `get_interleave_line(&self, sep: &str) -> Vec<StyledString>` -- Interleave title and value and output
 //!    as string. `sep` is a string between title and value, `line_sep` is a string between each pair.
 //! * `sort(&self, tag: TagType, children: &mut Vec<ModelType>, reverse: bool)` -- Sort the children array by the sorting tag. If reverse if set
 //!    this function will sort in reverse order. TagType will be an enum type that decorate the struct.

--- a/resctl/below/src/dump/mod.rs
+++ b/resctl/below/src/dump/mod.rs
@@ -26,6 +26,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail, Result};
+use cursive::utils::markup::StyledString;
 use regex::Regex;
 use serde_json::{json, Value};
 

--- a/resctl/below/src/model/mod.rs
+++ b/resctl/below/src/model/mod.rs
@@ -16,6 +16,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{anyhow, Context, Result};
+use cursive::utils::markup::StyledString;
 
 use crate::util::{convert_bytes, fold_string, get_prefix};
 use below_derive::BelowDecor;

--- a/resctl/below/src/test/mod.rs
+++ b/resctl/below/src/test/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use cursive::utils::markup::StyledString;
 use once_cell::sync::Lazy;
 use slog::{self, error, o, Drain};
 use tempdir::TempDir;

--- a/resctl/below/src/test/test_decorators.rs
+++ b/resctl/below/src/test/test_decorators.rs
@@ -111,7 +111,7 @@ fn test_bdecor_field_function() {
     assert_eq!(model.get_loopback_str(&model), "12.6%");
     assert_eq!(model.get_route_str(&model), "12.6%");
     assert_eq!(
-        model.get_field_line(&model, &subfield),
+        model.get_field_line(&model, &subfield).source(),
         "12.6%   12.6%   0.0       -->10 12.6%   12.6%   3.30  "
     );
     assert_eq!(
@@ -161,7 +161,13 @@ fn test_bdecor_cmp_function() {
 fn test_bdecor_interleave() {
     let model = TestModel::new();
     let subfield = SubField::new();
-    assert_eq!(model.get_interleave_line(": ", "\n", &model, &subfield), "Usage  : 12.6%  \nUser   : 12.6%  \nSystem : 2.2%   \nL1 Cach:   -->10\nUsage  : 12.6%  \nUsage  : 12.6%  \nAggr : 3.30 \n");
+    let lines = model.get_interleave_line(": ", &model, &subfield);
+    let mut string_lines = String::new();
+    for line in lines {
+        string_lines += line.source();
+        string_lines += "\n";
+    }
+    assert_eq!(string_lines, "Usage  : 12.6%  \nUser   : 12.6%  \nSystem : 2.2%   \nL1 Cach:   -->10\nUsage  : 12.6%  \nUsage  : 12.6%  \nAggr : 3.30 \n");
 }
 
 #[test]

--- a/resctl/below/src/view/cgroup_tabs.rs
+++ b/resctl/below/src/view/cgroup_tabs.rs
@@ -21,6 +21,8 @@ use crate::view::cgroup_view::CgroupState;
 use crate::view::stats_view::StateCommon;
 use below_derive::BelowDecor;
 
+use cursive::utils::markup::StyledString;
+
 // All available sorting tags
 #[derive(Copy, Clone, PartialEq)]
 pub enum CgroupOrders {
@@ -89,14 +91,14 @@ pub trait CgroupTab {
     fn get_title_vec(&self, model: &CgroupModel) -> Vec<String>;
     fn depth(&mut self) -> &mut usize;
     fn collapse(&mut self) -> &mut bool;
-    fn get_field_line(&self, model: &CgroupModel) -> String;
+    fn get_field_line(&self, model: &CgroupModel) -> StyledString;
     fn sort(&self, sort_order: CgroupOrders, cgroups: &mut Vec<&CgroupModel>, reverse: bool);
     fn output_cgroup(
         &mut self,
         cgroup: &CgroupModel,
         state: &CgroupState,
         filter_out_set: &Option<HashSet<String>>,
-        output: &mut Vec<(String, String)>,
+        output: &mut Vec<(StyledString, String)>,
     ) {
         if let Some(set) = &filter_out_set {
             if set.contains(&cgroup.full_path) {
@@ -140,7 +142,7 @@ pub trait CgroupTab {
         }
     }
 
-    fn get_rows(&mut self, state: &CgroupState) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &CgroupState) -> Vec<(StyledString, String)> {
         let filter_out_set = if let Some(f) = &state.filter {
             Some(calculate_filter_out_set(&state.get_model(), &f))
         } else {
@@ -239,7 +241,7 @@ pub struct CgroupGeneral {
 impl CgroupTab for CgroupGeneral {
     impl_cgroup_tab!(CgroupGeneral);
 
-    fn get_field_line(&self, model: &CgroupModel) -> String {
+    fn get_field_line(&self, model: &CgroupModel) -> StyledString {
         self.get_field_line(&model, &model)
     }
 }
@@ -286,7 +288,7 @@ pub struct CgroupCPU {
 impl CgroupTab for CgroupCPU {
     impl_cgroup_tab!(CgroupCPU);
 
-    fn get_field_line(&self, model: &CgroupModel) -> String {
+    fn get_field_line(&self, model: &CgroupModel) -> StyledString {
         self.get_field_line(&model)
     }
 }
@@ -543,7 +545,7 @@ pub struct CgroupMem {
 impl CgroupTab for CgroupMem {
     impl_cgroup_tab!(CgroupMem);
 
-    fn get_field_line(&self, model: &CgroupModel) -> String {
+    fn get_field_line(&self, model: &CgroupModel) -> StyledString {
         self.get_field_line(&model)
     }
 }
@@ -626,7 +628,7 @@ pub struct CgroupIO {
 impl CgroupTab for CgroupIO {
     impl_cgroup_tab!(CgroupMem);
 
-    fn get_field_line(&self, model: &CgroupModel) -> String {
+    fn get_field_line(&self, model: &CgroupModel) -> StyledString {
         self.get_field_line(&model, &model)
     }
 }
@@ -695,7 +697,7 @@ pub struct CgroupPressure {
 impl CgroupTab for CgroupPressure {
     impl_cgroup_tab!(CgroupMem);
 
-    fn get_field_line(&self, model: &CgroupModel) -> String {
+    fn get_field_line(&self, model: &CgroupModel) -> StyledString {
         self.get_field_line(&model)
     }
 }

--- a/resctl/below/src/view/cgroup_view.rs
+++ b/resctl/below/src/view/cgroup_view.rs
@@ -16,6 +16,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
+use cursive::utils::markup::StyledString;
 use cursive::view::Identifiable;
 use cursive::views::{NamedView, SelectView, ViewRef};
 use cursive::Cursive;
@@ -246,7 +247,7 @@ impl ViewBridge for CgroupView {
         self.get_inner().get_title_vec(&model)
     }
 
-    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(StyledString, String)> {
         self.get_inner().get_rows(state)
     }
 }

--- a/resctl/below/src/view/core_tabs.rs
+++ b/resctl/below/src/view/core_tabs.rs
@@ -16,12 +16,14 @@ use crate::model::system::*;
 use crate::view::core_view::CoreState;
 use crate::view::stats_view::StateCommon;
 
+use cursive::utils::markup::StyledString;
+
 pub trait CoreTab {
     fn get_title_vec(&self, _: &SystemModel) -> Vec<String> {
         vec![format!("{:<20.20}", "Field"), format!("{:<20.20}", "Value")]
     }
 
-    fn get_rows(&mut self, state: &CoreState) -> Vec<(String, String)>;
+    fn get_rows(&mut self, state: &CoreState) -> Vec<(StyledString, String)>;
 }
 
 #[derive(Default, Clone)]
@@ -42,10 +44,10 @@ impl CoreTab for CoreCpu {
         res
     }
 
-    fn get_rows(&mut self, state: &CoreState) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &CoreState) -> Vec<(StyledString, String)> {
         let model = state.get_model();
 
-        let mut res: Vec<(String, String)> = model
+        let mut res: Vec<(StyledString, String)> = model
             .cpu
             .cpus
             .as_ref()
@@ -81,21 +83,21 @@ impl CoreTab for CoreCpu {
 pub struct CoreMem;
 
 impl CoreTab for CoreMem {
-    fn get_rows(&mut self, state: &CoreState) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &CoreState) -> Vec<(StyledString, String)> {
         let model = state.get_model();
 
         model
             .mem
-            .get_interleave_line(" ", "|")
-            .split('|')
+            .get_interleave_line(" ")
+            .iter()
             .filter(|s| {
                 if let Some(f) = &state.filter {
-                    s.contains(f)
+                    s.source().contains(f)
                 } else {
                     true
                 }
             })
-            .map(|s| (s.to_string(), "".into()))
+            .map(|s| (s.clone(), "".into()))
             .collect()
     }
 }
@@ -104,21 +106,21 @@ impl CoreTab for CoreMem {
 pub struct CoreVm;
 
 impl CoreTab for CoreVm {
-    fn get_rows(&mut self, state: &CoreState) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &CoreState) -> Vec<(StyledString, String)> {
         let model = state.get_model();
 
         model
             .vm
-            .get_interleave_line(" ", "|")
-            .split('|')
+            .get_interleave_line(" ")
+            .iter()
             .filter(|s| {
                 if let Some(f) = &state.filter {
-                    s.contains(f)
+                    s.source().contains(f)
                 } else {
                     true
                 }
             })
-            .map(|s| (s.to_string(), "".into()))
+            .map(|s| (s.clone(), "".into()))
             .collect()
     }
 }
@@ -141,7 +143,7 @@ impl CoreTab for CoreDisk {
         res
     }
 
-    fn get_rows(&mut self, state: &CoreState) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &CoreState) -> Vec<(StyledString, String)> {
         state
             .get_model_mut()
             .disks

--- a/resctl/below/src/view/core_view.rs
+++ b/resctl/below/src/view/core_view.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use cursive::utils::markup::StyledString;
 use cursive::view::Identifiable;
 use cursive::views::{NamedView, SelectView, ViewRef};
 use cursive::Cursive;
@@ -136,7 +137,7 @@ impl ViewBridge for CoreView {
         self.get_inner().get_title_vec(&model)
     }
 
-    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(StyledString, String)> {
         self.get_inner().get_rows(state)
     }
 }

--- a/resctl/below/src/view/process_tabs.rs
+++ b/resctl/below/src/view/process_tabs.rs
@@ -18,6 +18,8 @@ use crate::view::process_view::ProcessState;
 use crate::view::stats_view::StateCommon;
 use below_derive::BelowDecor;
 
+use cursive::utils::markup::StyledString;
+
 // All available sorting tags
 #[derive(Copy, Clone, PartialEq)]
 pub enum ProcessOrders {
@@ -50,7 +52,7 @@ impl Default for ProcessOrders {
 // Defines how to iterate through the process stats and generate get_rows for ViewBridge
 pub trait ProcessTab {
     fn get_title_vec(&self, model: &SingleProcessModel) -> Vec<String>;
-    fn get_field_line(&self, model: &SingleProcessModel) -> String;
+    fn get_field_line(&self, model: &SingleProcessModel) -> StyledString;
     fn sort(
         &self,
         sort_order: ProcessOrders,
@@ -58,7 +60,7 @@ pub trait ProcessTab {
         reverse: bool,
     );
 
-    fn get_rows(&mut self, state: &ProcessState) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &ProcessState) -> Vec<(StyledString, String)> {
         let unknown = "?".to_string();
         let process_model = state.get_model();
         let mut processes: Vec<&SingleProcessModel> =
@@ -191,7 +193,7 @@ pub struct ProcessGeneral {
 impl ProcessTab for ProcessGeneral {
     impl_process_tab!(ProcessGeneral);
 
-    fn get_field_line(&self, model: &SingleProcessModel) -> String {
+    fn get_field_line(&self, model: &SingleProcessModel) -> StyledString {
         self.get_field_line(&model, &model)
     }
 }
@@ -243,7 +245,7 @@ pub struct ProcessCPU {
 impl ProcessTab for ProcessCPU {
     impl_process_tab!(ProcessGeneral);
 
-    fn get_field_line(&self, model: &SingleProcessModel) -> String {
+    fn get_field_line(&self, model: &SingleProcessModel) -> StyledString {
         self.get_field_line(&model, &model)
     }
 }
@@ -287,7 +289,7 @@ pub struct ProcessMem {
 impl ProcessTab for ProcessMem {
     impl_process_tab!(ProcessGeneral);
 
-    fn get_field_line(&self, model: &SingleProcessModel) -> String {
+    fn get_field_line(&self, model: &SingleProcessModel) -> StyledString {
         self.get_field_line(&model)
     }
 }
@@ -332,7 +334,7 @@ pub struct ProcessIO {
 impl ProcessTab for ProcessIO {
     impl_process_tab!(ProcessGeneral);
 
-    fn get_field_line(&self, model: &SingleProcessModel) -> String {
+    fn get_field_line(&self, model: &SingleProcessModel) -> StyledString {
         self.get_field_line(&model, &model)
     }
 }

--- a/resctl/below/src/view/process_view.rs
+++ b/resctl/below/src/view/process_view.rs
@@ -16,6 +16,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use cursive::utils::markup::StyledString;
 use cursive::view::Identifiable;
 use cursive::views::{NamedView, SelectView, ViewRef};
 use cursive::Cursive;
@@ -218,7 +219,7 @@ impl ViewBridge for ProcessView {
         self.get_inner().get_title_vec(&model)
     }
 
-    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(String, String)> {
+    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(StyledString, String)> {
         self.get_inner().get_rows(state)
     }
 }

--- a/resctl/below/src/view/stats_view.rs
+++ b/resctl/below/src/view/stats_view.rs
@@ -18,6 +18,7 @@ use std::rc::Rc;
 
 use ::cursive::view::{Identifiable, Scrollable, View};
 use cursive::event::{Event, EventResult, EventTrigger, Key};
+use cursive::utils::markup::StyledString;
 use cursive::view::ViewWrapper;
 use cursive::views::{
     LinearLayout, NamedView, OnEventView, Panel, ResizedView, ScrollView, SelectView, ViewRef,
@@ -63,7 +64,7 @@ pub trait ViewBridge {
     /// The essential function that defines how a StatsView should fill
     /// the data. This function will iterate through the data, apply filter and sorting,
     /// return a Vec of (Stats String Line, Key) tuple.
-    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(String, String)>;
+    fn get_rows(&mut self, state: &Self::StateType) -> Vec<(StyledString, String)>;
 }
 
 /// StatsView is a view wrapper that wraps tabs, titles, and list of stats.


### PR DESCRIPTION
Summary:
We want to be able to colorize text on the screen. The
best (and probably only) way to do that is to hand cursive
`StyledString`s.

This diff refactors the generated functions a little bit. There
shouldn't be any end-user visible changes.

Differential Revision: D22909572

