### PR TITLE
ci: Fix dockerhub filter

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_push:
+    if: github.repository == 'facebookincubator/resctl'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,9 +19,6 @@ jobs:
     - name: Tag docker image
       run: docker tag below below/below:latest
     - name: Authenticate with docker registry
-      if: >
-        github.ref == 'refs/heads/master' &&
-        github.repository == 'facebookincubator/resctl'
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Instead of gating each step of the job, gate the job itself.

Also remove the check for master branch b/c it was already gated at the
top of the config.