### PR TITLE
Fix weird looking highlighted values in below

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ rustfilt = { git = "https://github.com/jsgf/rustfilt.git", rev = "8141fa7f1caee5
 tokio-core = { git = "https://github.com/bolinfest/tokio-core", rev = "5f37aa3c627d56ee49154bc851d6930f5ab4398f" }
 toml = { git = "https://github.com/jsgf/toml-rs", branch = "dotted-table-0.5.7" }
 enumset = { git = "https://github.com/danobi/enumset", rev = "4c01c583c27a725948fededbfb3461c572a669a4" }
+cursive_buffered_backend = { git = "https://github.com/chengxiong-ruan/cursive_buffered_backend", branch = "upgrade_cursive_core_from_v0.4.1"}

--- a/resctl/below/Cargo.toml
+++ b/resctl/below/Cargo.toml
@@ -26,7 +26,7 @@ slog_glog_fmt = { git = "https://github.com/facebookexperimental/rust-shed.git",
 stats = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
 anyhow = "1.0"
 async-trait = "0.1.29"
-cursive = { version = "0.15.0", default-features = false, features = ["crossterm", "termion"] }
+cursive = { version = "0.16.0", default-features = false, features = ["crossterm", "termion"] }
 libbpf-rs = "0.6.1"
 libc = "0.2"
 once_cell = "1.4"

--- a/resctl/below/common/Cargo.toml
+++ b/resctl/below/common/Cargo.toml
@@ -11,7 +11,7 @@ include = ["src/**/*.rs"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-cursive = { version = "0.15.0", default-features = false, features = ["crossterm", "termion"] }
+cursive = { version = "0.16.0", default-features = false, features = ["crossterm", "termion"] }
 humantime = "1.3"
 once_cell = "1.4"
 regex = "1.4.2"

--- a/resctl/below/src/test/fake_view.rs
+++ b/resctl/below/src/test/fake_view.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use cursive::views::ViewRef;
-use cursive::Cursive;
+use cursive::CursiveRunnable;
 
 use super::*;
 use view::{
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 pub struct FakeView {
-    pub inner: Cursive,
+    pub inner: CursiveRunnable,
 }
 
 // TODO Add view and controller related tests (T76419919)
@@ -37,7 +37,7 @@ impl FakeView {
         let mut collector = Collector::new(get_dummy_exit_data());
         let model = collector.update_model(&logger).expect("Fail to get model");
 
-        let mut inner = Cursive::dummy();
+        let mut inner = CursiveRunnable::dummy();
         inner.set_user_data(ViewState::new_with_advance(
             MainViewState::Cgroup,
             model,

--- a/resctl/below/view/Cargo.toml
+++ b/resctl/below/view/Cargo.toml
@@ -16,7 +16,7 @@ render = { path = "../render" }
 store = { path = "../store" }
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-cursive = { version = "0.15.0", default-features = false, features = ["crossterm", "termion"] }
+cursive = { version = "0.16.0", default-features = false, features = ["crossterm", "termion"] }
 cursive_buffered_backend = "0.4.1"
 humantime = "1.3"
 libc = "0.2"

--- a/resctl/below/view/src/lib.rs
+++ b/resctl/below/view/src/lib.rs
@@ -61,6 +61,7 @@ use cursive::theme::{BaseColor, Color, PaletteColor};
 use cursive::view::Identifiable;
 use cursive::views::{LinearLayout, OnEventView, Panel, ResizedView, StackView};
 use cursive::Cursive;
+use cursive::CursiveRunnable;
 use toml::value::Value;
 
 use common::open_source_shim;
@@ -91,7 +92,7 @@ mod tab_view;
 const BELOW_CMD_RC: &str = "/.config/below/cmdrc";
 
 pub struct View {
-    inner: Cursive,
+    inner: CursiveRunnable,
 }
 
 macro_rules! advance {
@@ -237,11 +238,12 @@ impl ViewState {
 
 impl View {
     pub fn new_with_advance(model: model::Model, mode: ViewMode) -> View {
-        let mut inner = cursive::Cursive::new(|| {
-            let termion_backend = cursive::backends::crossterm::Backend::init().unwrap();
-            Box::new(cursive_buffered_backend::BufferedBackend::new(
-                termion_backend,
-            ))
+        let mut inner = cursive::CursiveRunnable::new(|| {
+            cursive::backends::crossterm::Backend::init().map(|termion_backend| {
+                Box::new(cursive_buffered_backend::BufferedBackend::new(
+                    termion_backend,
+                )) as Box<(dyn cursive::backend::Backend)>
+            })
         });
         inner.set_user_data(ViewState::new_with_advance(
             MainViewState::Cgroup,


### PR DESCRIPTION
Summary:
1. Upgrade `Cursive` to v0.16.3
2. patch `cursive_buffered_backend` with a temp fork before v0.4.2 is released. This is needed to avoid Rust being confused by `Backend` trait from different versions of `cursive_core`

Reviewed By: dschatzberg

Differential Revision: D25987535

