### PR TITLE
substitute surrogates in log file

### DIFF
--- a/build/fbcode_builder/getdeps/runcmd.py
+++ b/build/fbcode_builder/getdeps/runcmd.py
@@ -51,7 +51,7 @@ def run_cmd(cmd, env=None, cwd=None, allow_fail=False, log_file=None):
         sys.stdout.buffer.write(msg.encode(errors="surrogateescape"))
 
     if log_file is not None:
-        with open(log_file, "a", encoding="utf-8") as log:
+        with open(log_file, "a", encoding="utf-8", errors="surrogateescape") as log:
 
             def log_function(msg):
                 log.write(msg)


### PR DESCRIPTION
Summary:
D26025779 (https://github.com/facebookincubator/resctl/commit/ceaa95ed3c60605459712ce478380806cecf3c9e) may have broken the getdeps build when logging
surrogates. Use errors=surrogateescape to try to avoid that.

Differential Revision: D26079717

