### PR TITLE
Fix github CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN /root/.cargo/bin/cargo install libbpf-cargo
 
 # Build below
 WORKDIR resctl
-RUN /root/.cargo/bin/cargo libbpf make -- --release --package resctl_below
+RUN /root/.cargo/bin/cargo libbpf make -- --release --package below
 
 # Run tests if requested
 RUN if [[ -n "$RUN_TESTS" ]]; then     \


### PR DESCRIPTION
Summary: https://github.com/facebookincubator/resctl/commit/d0afc964fa855fd4e25da61bebc19cd517e9458c changes below cargo name from resctl_below to below. Update related CI files to fix.

Differential Revision: D27019710

