### PR TITLE
Use released cursive_tab and cursive_buffered_backend version (#76)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ addr2line = { git = "https://github.com/gimli-rs/addr2line.git", rev = "0b6b6018
 bytecount = { git = "https://github.com/llogiq/bytecount", rev = "469eaf8395c99397cd64d059737a9054aa014088" }
 chashmap = { git = "https://gitlab.redox-os.org/ahornby/chashmap", rev = "901ace2ca3cdbc2095adb1af111d211e254e2aae" }
 const-random = { git = "https://github.com/fbsource/const-random", rev = "374c5b46427fe2ffbf6acbd9c1687e0f1a809f95" }
-cursive_buffered_backend = { git = "https://github.com/chengxiong-ruan/cursive_buffered_backend", branch = "upgrade_cursive_core_from_v0.4.1" }
 enumset = { git = "https://github.com/danobi/enumset", rev = "4c01c583c27a725948fededbfb3461c572a669a4" }
 gotham = { git = "https://github.com/krallin/gotham.git", rev = "6c1612c7189893f31c6c3fa2dda11c0b6d83e1ac" }
 gotham-02 = { package = "gotham", git = "https://github.com/krallin/gotham-02.git", rev = "1eb3b976c31e7e4334b188f3abfa5cc2e5cae033" }

--- a/resctl/below/Cargo.toml
+++ b/resctl/below/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { version = "1.0", features = ["float_roundtrip"] }
 signal-hook = "0.1"
 slog = { version = "2.5", features = ["max_level_debug"] }
 slog-async = "2.3"
+slog-term = "2.4.2"
 slog_glog_fmt = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
 store = { package = "below-store", version = "0.1.0", path = "store" }
@@ -43,5 +44,4 @@ walkdir = "2.2.9"
 futures = { version = "0.3.13", features = ["async-await", "compat"] }
 maplit = "1.0"
 rand = { version = "0.7", features = ["small_rng"] }
-slog-term = "2.4.2"
 tempdir = "0.3"

--- a/resctl/below/view/Cargo.toml
+++ b/resctl/below/view/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 common = { package = "below-common", version = "0.1.0", path = "../common" }
 cursive = { version = "0.16.0", features = ["crossterm", "termion"], default-features = false }
-cursive_buffered_backend = "0.4.1"
+cursive_buffered_backend = "0.5.0"
 humantime = "1.3"
 libc = "0.2.86"
 model = { package = "below-model", version = "0.1.0", path = "../model" }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexperimental/eden/pull/76

Use released version to fix cursive_core version conflicts.

Differential Revision: D27032206

