### PR TITLE
Remove slog_glog_fmt and stats dependencies in open source

### DIFF
--- a/resctl/below/Cargo.toml
+++ b/resctl/below/Cargo.toml
@@ -30,8 +30,6 @@ signal-hook = "0.1"
 slog = { version = "2.5", features = ["max_level_trace"] }
 slog-async = "2.3"
 slog-term = "2.4.2"
-slog_glog_fmt = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
-stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
 store = { package = "below-store", version = "0.1.0", path = "store" }
 structopt = "0.3.21"
 tokio = { version = "0.2.25", features = ["full", "test-util"] }


### PR DESCRIPTION
Summary:
Per title. slog_glog_fmt and stats are only used internally -- uses
are not exported to GitHub.

After this, we just need to get rid of fbthrift/thrift_compiler and
then all open source dependencies will be from crates.io.

Differential Revision: D28264979

