### PR TITLE
Remove Bytes dependency to fix build

### DIFF
--- a/resctl/below/store/Cargo.toml
+++ b/resctl/below/store/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 anyhow = "1.0"
 below_thrift = { version = "0.1.0", path = "../if" }
 bitflags = "1.2"
-bytes = { version = "1.0", features = ["serde"] }
 common = { package = "below-common", version = "0.1.0", path = "../common" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "master" }
 futures = { version = "0.3.13", features = ["async-await", "compat"] }

--- a/resctl/below/store/src/lib.rs
+++ b/resctl/below/store/src/lib.rs
@@ -141,7 +141,6 @@ macro_rules! get_index_entries {
 }
 
 enum SerializedFrame<'a> {
-    Bytes(bytes::Bytes),
     Copy(Vec<u8>),
     Slice(&'a [u8]),
 }
@@ -149,7 +148,6 @@ enum SerializedFrame<'a> {
 impl<'a> SerializedFrame<'a> {
     fn data(&self) -> &[u8] {
         match self {
-            SerializedFrame::Bytes(b) => &b,
             SerializedFrame::Copy(v) => &v,
             SerializedFrame::Slice(s) => s,
         }
@@ -164,7 +162,7 @@ fn serialize_frame(data: &DataFrame, compress: bool) -> Result<SerializedFrame> 
             0,
         )?))
     } else {
-        Ok(SerializedFrame::Bytes(serialized))
+        Ok(SerializedFrame::Copy(serialized.to_vec()))
     }
 }
 


### PR DESCRIPTION
Summary:
Open source build is failing since D28537964 (https://github.com/facebookincubator/resctl/commit/76385eef8e9d8c9f9bf7b21ba7f25b47c480984f) since fbthrift_ext is
still on Bytes 0.5.

Easiest if we just remove the Bytes dependency here altogether.

Differential Revision: D28782402

