### PR TITLE
Update futures family to 0.3.32

### DIFF
--- a/below/model/Cargo.toml
+++ b/below/model/Cargo.toml
@@ -30,4 +30,4 @@ slog = { version = "2.8.2", features = ["max_level_trace", "nested-values"] }
 tc = { package = "below-tc", version = "0.11.0", path = "../tc" }
 
 [dev-dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }

--- a/below/store/Cargo.toml
+++ b/below/store/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.98"
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 bytes = { version = "1.11.1", features = ["serde"] }
 common = { package = "below-common", version = "0.11.0", path = "../common" }
 humantime = "2.1"


### PR DESCRIPTION
Summary: Update the futures family of Rust crates from 0.3.30/0.3.31 to 0.3.32: futures, futures-channel, futures-core, and futures-util. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684256
