### PR TITLE
Add arm64 build to docker image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -7,22 +7,52 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_push:
+  build:
     if: github.repository == 'facebookincubator/below'
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            arch: amd64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v2
-    - name: Build docker image
-      run: >
-        docker build
-        -t below
-        .
-    - name: Tag docker image
-      run: docker tag below below/below:latest
     - name: Authenticate with docker registry
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
-    - name: Push docker image
-      run: docker push below/below:latest
+    - name: Build and push docker image by digest
+      run: |
+        docker buildx create --use
+        docker buildx build \
+          --output "type=image,name=below/below,push-by-digest=true,name-canonical=true,push=true" \
+          --metadata-file metadata.json \
+          .
+    - name: Upload metadata
+      uses: actions/upload-artifact@v4
+      with:
+        name: metadata-${{ matrix.arch }}
+        path: metadata.json
+
+  merge_manifests_push:
+    if: github.repository == 'facebookincubator/below'
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Download metadata
+      uses: actions/download-artifact@v4
+      with:
+        path: metadata
+        pattern: metadata-*
+    - name: Authenticate with docker registry
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+    - name: Merge manifests and push
+      run: |
+        docker buildx imagetools create -t below/below:latest \
+          $(for f in metadata/*/metadata.json; do echo "below/below@$(jq -r '."containerimage.digest"' "$f")"; done)


### PR DESCRIPTION
Hi, I want to run below from a docker image on both x86 and arm machines. Currently github action only builds x86 image.

Docker supports multiarch images, which are created by first publishing two images without a tag (just accessible by a hash) and then merging manifests into one, which references correct manifests for different architectures.

I tested this on my fork and it works. Result: https://hub.docker.com/r/nuhotetotniksvoboden/below/tags

<img width="944" height="446" alt="2026-05-21_00-38" src="https://github.com/user-attachments/assets/59730922-c47c-414b-8b91-da4d0c29e38d" />

And the correct binaries are compiled:

```
$ uname -a
Linux devserver 6.8.0-111-generic #111-Ubuntu SMP PREEMPT_DYNAMIC Sat Apr 11 23:16:02 UTC 2026 x86_64 GNU/Linux

$ podman run --rm docker.io/nuhotetotniksvoboden/below --help
Usage: below [OPTIONS] [COMMAND]

Commands:
  live      Display live system data (interactive) (default)
  record    Record local system data (daemon mode)
  replay    Replay historical data (interactive)
  debug     Debugging facilities (for development use)
  dump      Dump historical data into parseable text format
  snapshot  Create a historical snapshot file for a given time range
  help      Print this message or the help of the given subcommand(s)

Options:
      --config <CONFIG>  [default: /etc/below/below.conf]
  -d, --debug
  -h, --help             Print help
```

```
$ uname -a
Linux raspberry-pi 6.8.0-1043-raspi #47-Ubuntu SMP PREEMPT_DYNAMIC Fri Oct 17 22:33:56 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux

$ podman run --rm docker.io/nuhotetotniksvoboden/below --help
Usage: below [OPTIONS] [COMMAND]

Commands:
  live      Display live system data (interactive) (default)
  record    Record local system data (daemon mode)
  replay    Replay historical data (interactive)
  debug     Debugging facilities (for development use)
  dump      Dump historical data into parseable text format
  snapshot  Create a historical snapshot file for a given time range
  help      Print this message or the help of the given subcommand(s)

Options:
      --config <CONFIG>  [default: /etc/below/below.conf]
  -d, --debug
  -h, --help             Print help
```