### PR TITLE
refresh 10 crates to latest compatible versions

### DIFF
--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 cursive = { version = "0.21.1", features = ["crossterm-backend"], default-features = false }
 humantime = "2.1"
 once_cell = "1.21.4"

--- a/below/store/Cargo.toml
+++ b/below/store/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 bytes = { version = "1.11.1", features = ["serde"] }
 common = { package = "below-common", version = "0.11.0", path = "../common" }
 humantime = "2.1"

--- a/below/view/Cargo.toml
+++ b/below/view/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 common = { package = "below-common", version = "0.11.0", path = "../common" }
 crossterm = { version = "0.29", features = ["event-stream", "serde"] }
 cursive = { version = "0.21.1", features = ["crossterm-backend"], default-features = false }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/hermit/pull/66

X-link: https://github.com/facebookexperimental/dapper/pull/3

X-link: https://github.com/facebook/hhvm/pull/9791

X-link: https://github.com/facebook/ocamlrep/pull/93

X-link: https://github.com/facebook/buck2-shims-meta/pull/17

X-link: https://github.com/facebook/flow/pull/9420

X-link: https://github.com/WhatsApp/erlang-language-platform/pull/215

X-link: https://github.com/facebook/buck2/pull/1335

X-link: https://github.com/meta-pytorch/monarch/pull/4193

Refreshes 10 third-party Rust crates to their latest semver-compatible versions. These are dependencies used by the hzdb/metavr CLI (`arvr/apps/hzdb`) that were behind in the shared lockfile; the bumps apply repo-wide since `third-party/rust` is shared.

- `bitflags` `2.11.1` -> `2.13.0`
- `bumpalo` `3.20.2` -> `3.20.3`
- `cc` `1.2.62` -> `1.2.63` (additively vendors `shlex` `2.0.1` as a new transitive of `cc`)
- `chrono` `0.4.44` -> `0.4.45`
- `http` `1.4.0` -> `1.4.1`
- `hyper` `1.9.0` -> `1.10.1`
- `memchr` `2.8.0` -> `2.8.1`
- `reqwest` `0.13.2` -> `0.13.4`
- `unicode-segmentation` `1.13.2` -> `1.13.3`
- `zerocopy` `0.8.48` -> `0.8.50`

All are patch/minor (semver-compatible) bumps requiring no first-party code changes. Mirrored the applicable bumps into the github shim manifest (`fbcode/github/standard/shim/third-party/rust/Cargo.toml`) for `bitflags`, `bumpalo`, `chrono`, `http`, `hyper`, `memchr`, and `unicode-segmentation`. Regenerated with `reindeer vendor`, which also refreshed 255 first-party `Cargo.toml` manifests via autocargo. No first-party Rust source changes were needed.

Differential Revision: D107740437
