### PR TITLE
view: support expanding a cgroup's processes in the cgroup view

### DIFF
--- a/below/view/src/cgroup_tabs.rs
+++ b/below/view/src/cgroup_tabs.rs
@@ -88,6 +88,7 @@ pub struct CgroupTab {
     cgroup_name: CgroupViewItem,
     cgroup_name_collapsed: CgroupViewItem,
     process_name: ProcessViewItem,
+    process_name_header: ProcessViewItem,
 }
 
 /// Defines how to iterate through the cgroup and generate get_rows function for ViewBridge
@@ -109,6 +110,11 @@ impl CgroupTab {
             process_name: ViewItem::from_default(model::SingleProcessModelFieldId::Comm)
                 .update(cgroup_name_config.clone())
                 .update(Rc::new().indented_prefix(get_prefix(false))),
+            // Same alignment as process_name but with a blank prefix, for the
+            // column title row shown above the process rows
+            process_name_header: ViewItem::from_default(model::SingleProcessModelFieldId::Comm)
+                .update(cgroup_name_config.clone())
+                .update(Rc::new().indented_prefix(" ".repeat(get_prefix(false).chars().count()))),
         }
     }
 
@@ -163,6 +169,29 @@ impl CgroupTab {
         )
     }
 
+    /// Column title row shown above the process rows of an expanded cgroup,
+    /// since the view's own column titles describe cgroup fields.
+    fn get_process_header_line(&self, depth: usize, offset: Option<usize>) -> StyledString {
+        let title = self
+            .process_name_header
+            .config
+            .render_config
+            .get_title()
+            .to_owned();
+        let mut line = self
+            .process_name_header
+            .config
+            .render_indented(Some(model::Field::Str(title)), depth);
+        line.append_plain(" ");
+
+        for item in EXPANDED_PROCS_VIEW_ITEMS.iter().skip(offset.unwrap_or(0)) {
+            line.append_plain(item.config.render_title());
+            line.append_plain(" ");
+        }
+
+        line
+    }
+
     pub fn get_titles(&self) -> ColumnTitles {
         ColumnTitles {
             titles: std::iter::once(&self.cgroup_name)
@@ -215,6 +244,10 @@ impl CgroupTab {
                 && let Some(procs) = procs_map.get(cgroup.data.full_path.as_str())
             {
                 let depth = cgroup.data.depth as usize + 1;
+                output.push((
+                    self.get_process_header_line(depth, offset),
+                    cgroup.data.full_path.clone(),
+                ));
                 for process in procs {
                     output.push((
                         self.get_process_line(process, depth, offset),
@@ -720,13 +753,38 @@ mod tests {
         state.expanded_procs_cgroups.insert("/child1".to_owned());
         let rows = tab().get_rows(&state, None);
 
-        // Process row shows up directly under its cgroup, keyed by the
-        // cgroup's full path
+        // A header row and the process row show up directly under the
+        // expanded cgroup, keyed by the cgroup's full path
         assert_eq!(
             keys(&rows),
-            vec!["", "/child1", "/child1", "/child1/nested", "/other"]
+            vec![
+                "",
+                "/child1",
+                "/child1",
+                "/child1",
+                "/child1/nested",
+                "/other"
+            ]
         );
-        let proc_row = &rows[2].0;
+        let header_row = &rows[2].0;
+        assert!(
+            header_row.source().contains("Comm"),
+            "got: {}",
+            header_row.source()
+        );
+        assert!(
+            header_row.source().contains("Pid"),
+            "got: {}",
+            header_row.source()
+        );
+        assert!(
+            !header_row.spans().any(|span| span.attr.color.front
+                == cursive::theme::ColorType::Color(cursive::theme::Color::Light(
+                    cursive::theme::BaseColor::Blue
+                ))),
+            "header row should keep the default color"
+        );
+        let proc_row = &rows[3].0;
         let source = proc_row.source();
         assert!(source.contains("proc_a"), "got: {}", source);
         assert!(source.contains("100"), "got: {}", source);
@@ -774,9 +832,10 @@ mod tests {
         let rows = tab().get_rows(&state, None);
         assert_eq!(
             keys(&rows),
-            vec!["", "", "/child1", "/child1/nested", "/other"]
+            vec!["", "", "", "/child1", "/child1/nested", "/other"]
         );
-        assert!(rows[1].0.source().contains("proc_root"));
+        assert!(rows[1].0.source().contains("Comm"));
+        assert!(rows[2].0.source().contains("proc_root"));
     }
 
     #[test]

--- a/below/view/src/cgroup_tabs.rs
+++ b/below/view/src/cgroup_tabs.rs
@@ -27,6 +27,7 @@ use model::SingleProcessModel;
 use model::sort_queriables;
 
 use crate::cgroup_view::CgroupState;
+use crate::render::ViewConfig;
 use crate::render::ViewItem;
 use crate::stats_view::ColumnTitles;
 use crate::stats_view::StateCommon;
@@ -88,7 +89,7 @@ pub struct CgroupTab {
     cgroup_name: CgroupViewItem,
     cgroup_name_collapsed: CgroupViewItem,
     process_name: ProcessViewItem,
-    process_name_header: ProcessViewItem,
+    process_name_header: ViewConfig,
 }
 
 /// Defines how to iterate through the cgroup and generate get_rows function for ViewBridge
@@ -98,6 +99,10 @@ impl CgroupTab {
         use base_render::RenderConfigBuilder as Rc;
         use common::util::get_prefix;
         let cgroup_name_item = ViewItem::from_default(SingleCgroupModelFieldId::Name);
+        let process_name = ViewItem::from_default(model::SingleProcessModelFieldId::Comm)
+            .update(cgroup_name_config.clone())
+            .update(Rc::new().indented_prefix(" ".repeat(get_prefix(false).chars().count())));
+        let process_name_header = process_name.config.clone();
         Self {
             view_items,
             cgroup_name: cgroup_name_item
@@ -107,14 +112,8 @@ impl CgroupTab {
             cgroup_name_collapsed: cgroup_name_item
                 .update(cgroup_name_config.clone())
                 .update(Rc::new().indented_prefix(get_prefix(true))),
-            process_name: ViewItem::from_default(model::SingleProcessModelFieldId::Comm)
-                .update(cgroup_name_config.clone())
-                .update(Rc::new().indented_prefix(get_prefix(false))),
-            // Same alignment as process_name but with a blank prefix, for the
-            // column title row shown above the process rows
-            process_name_header: ViewItem::from_default(model::SingleProcessModelFieldId::Comm)
-                .update(cgroup_name_config.clone())
-                .update(Rc::new().indented_prefix(" ".repeat(get_prefix(false).chars().count()))),
+            process_name,
+            process_name_header,
         }
     }
 
@@ -154,7 +153,14 @@ impl CgroupTab {
         depth: usize,
         offset: Option<usize>,
     ) -> StyledString {
-        let mut line = self.process_name.render_indented_depth(model, depth);
+        // Color the process name to mark the row as a process row. The stat
+        // fields keep their own rendering so field highlights still apply.
+        let mut line = StyledString::styled(
+            self.process_name
+                .render_indented_depth(model, depth)
+                .source(),
+            cursive::theme::Color::Light(cursive::theme::BaseColor::Blue),
+        );
         line.append_plain(" ");
 
         for item in EXPANDED_PROCS_VIEW_ITEMS.iter().skip(offset.unwrap_or(0)) {
@@ -162,11 +168,7 @@ impl CgroupTab {
             line.append_plain(" ");
         }
 
-        // Color process rows to distinguish them from cgroup rows
-        StyledString::styled(
-            line.source(),
-            cursive::theme::Color::Light(cursive::theme::BaseColor::Blue),
-        )
+        line
     }
 
     /// Column title row shown above the process rows of an expanded cgroup,
@@ -174,13 +176,11 @@ impl CgroupTab {
     fn get_process_header_line(&self, depth: usize, offset: Option<usize>) -> StyledString {
         let title = self
             .process_name_header
-            .config
             .render_config
             .get_title()
             .to_owned();
         let mut line = self
             .process_name_header
-            .config
             .render_indented(Some(model::Field::Str(title)), depth);
         line.append_plain(" ");
 
@@ -207,7 +207,7 @@ impl CgroupTab {
         cgroup: &CgroupModel,
         state: &CgroupState,
         filtered_set: &Option<HashSet<String>>,
-        cgroup_to_procs: &Option<HashMap<&str, Vec<&SingleProcessModel>>>,
+        cgroup_to_procs: &HashMap<&str, Vec<&SingleProcessModel>>,
         output: &mut Vec<(StyledString, String)>,
         offset: Option<usize>,
     ) {
@@ -240,9 +240,7 @@ impl CgroupTab {
             // Show member processes of an expanded cgroup as child rows. They
             // carry the cgroup's full_path as key so that path-based handlers
             // act on the enclosing cgroup when a process row is selected.
-            if let Some(procs_map) = cgroup_to_procs
-                && let Some(procs) = procs_map.get(cgroup.data.full_path.as_str())
-            {
+            if let Some(procs) = cgroup_to_procs.get(cgroup.data.full_path.as_str()) {
                 let depth = cgroup.data.depth as usize + 1;
                 output.push((
                     self.get_process_header_line(depth, offset),
@@ -297,36 +295,32 @@ impl CgroupTab {
         // directly in an expanded cgroup are included, not those in descendant
         // cgroups, so a process shows up only under its own cgroup.
         let process_model = state.process_model.lock().unwrap();
-        let cgroup_to_procs: Option<HashMap<&str, Vec<&SingleProcessModel>>> =
-            if state.expanded_procs_cgroups.is_empty() {
-                None
-            } else {
-                let mut map: HashMap<&str, Vec<&SingleProcessModel>> = HashMap::new();
-                for spm in process_model.processes.values() {
-                    // Processes in the root cgroup report "/" while the root
-                    // cgroup's full_path is ""
-                    let cgroup = match spm.cgroup.as_deref() {
-                        Some("/") => "",
-                        Some(cgroup) => cgroup,
-                        None => continue,
-                    };
-                    if state.expanded_procs_cgroups.contains(cgroup) {
-                        map.entry(cgroup).or_default().push(spm);
-                    }
+        let mut cgroup_to_procs: HashMap<&str, Vec<&SingleProcessModel>> = HashMap::new();
+        if !state.expanded_procs_cgroups.is_empty() {
+            for spm in process_model.processes.values() {
+                // Processes in the root cgroup report "/" while the root
+                // cgroup's full_path is ""
+                let cgroup = match spm.cgroup.as_deref() {
+                    Some("/") => "",
+                    Some(cgroup) => cgroup,
+                    None => continue,
+                };
+                if state.expanded_procs_cgroups.contains(cgroup) {
+                    cgroup_to_procs.entry(cgroup).or_default().push(spm);
                 }
-                // Follow the view's sort order when it maps to a process
-                // field. Otherwise keep pid order from BTreeMap iteration.
-                if let Some(process_sort) = state
-                    .sort_order
-                    .as_ref()
-                    .and_then(cgroup_sort_to_process_sort)
-                {
-                    for procs in map.values_mut() {
-                        sort_queriables(procs, &process_sort, state.reverse);
-                    }
+            }
+            // Follow the view's sort order when it maps to a process
+            // field. Otherwise keep pid order from BTreeMap iteration.
+            if let Some(process_sort) = state
+                .sort_order
+                .as_ref()
+                .and_then(cgroup_sort_to_process_sort)
+            {
+                for procs in cgroup_to_procs.values_mut() {
+                    sort_queriables(procs, &process_sort, state.reverse);
                 }
-                Some(map)
-            };
+            }
+        }
         let mut rows = Vec::new();
         self.output_cgroup(
             &state.get_model(),
@@ -708,10 +702,13 @@ mod tests {
 
     fn fake_process_model() -> ProcessModel {
         let mut processes = BTreeMap::new();
-        processes.insert(
-            100,
-            fake_process(100, "proc_a", "/bin/proc_a --flag", "/child1"),
-        );
+        let mut proc_a = fake_process(100, "proc_a", "/bin/proc_a --flag", "/child1");
+        // Above the cpu highlight threshold so that below renders the number red
+        proc_a.cpu = Some(model::ProcessCpuModel {
+            usage_pct: Some(150.0),
+            ..Default::default()
+        });
+        processes.insert(100, proc_a);
         processes.insert(
             200,
             fake_process(200, "proc_b", "/bin/proc_b", "/child1/nested"),
@@ -796,12 +793,22 @@ mod tests {
                 .any(|(row, _key)| row.source().contains("proc_b")),
             "expansion should only show the cgroup's own processes"
         );
+        let span_color = |color: cursive::theme::BaseColor| {
+            cursive::theme::ColorType::Color(cursive::theme::Color::Light(color))
+        };
+        // The process name is colored blue to mark the row, while the stat
+        // fields are left alone so below can still color them its usual way
+        // e.g. turning the cpu stat red when a process is over a threshold.
+        assert_eq!(
+            proc_row.spans().next().unwrap().attr.color.front,
+            span_color(cursive::theme::BaseColor::Blue),
+            "process name should render in blue"
+        );
         assert!(
-            proc_row.spans().all(|span| span.attr.color.front
-                == cursive::theme::ColorType::Color(cursive::theme::Color::Light(
-                    cursive::theme::BaseColor::Blue
-                ))),
-            "process rows should render in blue"
+            proc_row
+                .spans()
+                .any(|span| span.attr.color.front == span_color(cursive::theme::BaseColor::Red)),
+            "cpu over the highlight threshold should render highlighted"
         );
     }
 

--- a/below/view/src/cgroup_tabs.rs
+++ b/below/view/src/cgroup_tabs.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
 use base_render::RenderConfig;
 use cursive::utils::markup::StyledString;
@@ -21,6 +23,7 @@ use model::CgroupModelFieldId;
 use model::Queriable;
 use model::SingleCgroupModel;
 use model::SingleCgroupModelFieldId;
+use model::SingleProcessModel;
 use model::sort_queriables;
 
 use crate::cgroup_view::CgroupState;
@@ -31,12 +34,60 @@ use crate::stats_view::StateCommon;
 /// Renders corresponding Fields From CgroupModel.
 type CgroupViewItem = ViewItem<model::SingleCgroupModelFieldId>;
 
+/// Renders corresponding Fields From ProcessModel.
+type ProcessViewItem = ViewItem<model::SingleProcessModelFieldId>;
+
+/// Columns shown for the processes of an expanded cgroup.
+static EXPANDED_PROCS_VIEW_ITEMS: LazyLock<Vec<ProcessViewItem>> = LazyLock::new(|| {
+    use model::ProcessCpuModelFieldId::UsagePct;
+    use model::ProcessMemoryModelFieldId::RssBytes;
+    use model::SingleProcessModelFieldId::Cmdline;
+    use model::SingleProcessModelFieldId::Cpu;
+    use model::SingleProcessModelFieldId::Mem;
+    use model::SingleProcessModelFieldId::Pid;
+    use model::SingleProcessModelFieldId::State;
+    vec![
+        ViewItem::from_default(Pid),
+        ViewItem::from_default(State),
+        ViewItem::from_default(Cpu(UsagePct)),
+        ViewItem::from_default(Mem(RssBytes)),
+        ViewItem::from_default(Cmdline),
+    ]
+});
+
+/// Maps a cgroup sort order to the equivalent process field so that processes
+/// of expanded cgroups follow the view's sort order where one exists.
+fn cgroup_sort_to_process_sort(
+    sort_order: &SingleCgroupModelFieldId,
+) -> Option<model::SingleProcessModelFieldId> {
+    use model::CgroupCpuModelFieldId as CgroupCpu;
+    use model::CgroupIoModelFieldId as CgroupIo;
+    use model::CgroupMemoryModelFieldId as CgroupMem;
+    use model::ProcessCpuModelFieldId as ProcessCpu;
+    use model::ProcessIoModelFieldId as ProcessIo;
+    use model::ProcessMemoryModelFieldId as ProcessMem;
+    use model::SingleCgroupModelFieldId as Cgroup;
+    use model::SingleProcessModelFieldId as Process;
+
+    match sort_order {
+        Cgroup::Cpu(CgroupCpu::UsagePct) => Some(Process::Cpu(ProcessCpu::UsagePct)),
+        Cgroup::Cpu(CgroupCpu::UserPct) => Some(Process::Cpu(ProcessCpu::UserPct)),
+        Cgroup::Cpu(CgroupCpu::SystemPct) => Some(Process::Cpu(ProcessCpu::SystemPct)),
+        Cgroup::Mem(CgroupMem::Total) => Some(Process::Mem(ProcessMem::RssBytes)),
+        Cgroup::Io(CgroupIo::RbytesPerSec) => Some(Process::Io(ProcessIo::RbytesPerSec)),
+        Cgroup::Io(CgroupIo::WbytesPerSec) => Some(Process::Io(ProcessIo::WbytesPerSec)),
+        Cgroup::Io(CgroupIo::RwbytesPerSec) => Some(Process::Io(ProcessIo::RwbytesPerSec)),
+        _ => None,
+    }
+}
+
 /// A collection of CgroupViewItem.
 #[derive(Clone)]
 pub struct CgroupTab {
     pub view_items: Vec<CgroupViewItem>,
     cgroup_name: CgroupViewItem,
     cgroup_name_collapsed: CgroupViewItem,
+    process_name: ProcessViewItem,
 }
 
 /// Defines how to iterate through the cgroup and generate get_rows function for ViewBridge
@@ -55,6 +106,9 @@ impl CgroupTab {
             cgroup_name_collapsed: cgroup_name_item
                 .update(cgroup_name_config.clone())
                 .update(Rc::new().indented_prefix(get_prefix(true))),
+            process_name: ViewItem::from_default(model::SingleProcessModelFieldId::Comm)
+                .update(cgroup_name_config.clone())
+                .update(Rc::new().indented_prefix(get_prefix(false))),
         }
     }
 
@@ -88,6 +142,27 @@ impl CgroupTab {
         line
     }
 
+    fn get_process_line(
+        &self,
+        model: &SingleProcessModel,
+        depth: usize,
+        offset: Option<usize>,
+    ) -> StyledString {
+        let mut line = self.process_name.render_indented_depth(model, depth);
+        line.append_plain(" ");
+
+        for item in EXPANDED_PROCS_VIEW_ITEMS.iter().skip(offset.unwrap_or(0)) {
+            line.append(item.render(model));
+            line.append_plain(" ");
+        }
+
+        // Color process rows to distinguish them from cgroup rows
+        StyledString::styled(
+            line.source(),
+            cursive::theme::Color::Light(cursive::theme::BaseColor::Blue),
+        )
+    }
+
     pub fn get_titles(&self) -> ColumnTitles {
         ColumnTitles {
             titles: std::iter::once(&self.cgroup_name)
@@ -103,6 +178,7 @@ impl CgroupTab {
         cgroup: &CgroupModel,
         state: &CgroupState,
         filtered_set: &Option<HashSet<String>>,
+        cgroup_to_procs: &Option<HashMap<&str, Vec<&SingleProcessModel>>>,
         output: &mut Vec<(StyledString, String)>,
         offset: Option<usize>,
     ) {
@@ -130,6 +206,21 @@ impl CgroupTab {
 
             if collapsed {
                 continue;
+            }
+
+            // Show member processes of an expanded cgroup as child rows. They
+            // carry the cgroup's full_path as key so that path-based handlers
+            // act on the enclosing cgroup when a process row is selected.
+            if let Some(procs_map) = cgroup_to_procs
+                && let Some(procs) = procs_map.get(cgroup.data.full_path.as_str())
+            {
+                let depth = cgroup.data.depth as usize + 1;
+                for process in procs {
+                    output.push((
+                        self.get_process_line(process, depth, offset),
+                        cgroup.data.full_path.clone(),
+                    ));
+                }
             }
 
             let mut children = Vec::from_iter(&cgroup.children);
@@ -169,8 +260,49 @@ impl CgroupTab {
         } else {
             None
         };
+        // Index processes of expanded cgroups by cgroup path. Only processes
+        // directly in an expanded cgroup are included, not those in descendant
+        // cgroups, so a process shows up only under its own cgroup.
+        let process_model = state.process_model.lock().unwrap();
+        let cgroup_to_procs: Option<HashMap<&str, Vec<&SingleProcessModel>>> =
+            if state.expanded_procs_cgroups.is_empty() {
+                None
+            } else {
+                let mut map: HashMap<&str, Vec<&SingleProcessModel>> = HashMap::new();
+                for spm in process_model.processes.values() {
+                    // Processes in the root cgroup report "/" while the root
+                    // cgroup's full_path is ""
+                    let cgroup = match spm.cgroup.as_deref() {
+                        Some("/") => "",
+                        Some(cgroup) => cgroup,
+                        None => continue,
+                    };
+                    if state.expanded_procs_cgroups.contains(cgroup) {
+                        map.entry(cgroup).or_default().push(spm);
+                    }
+                }
+                // Follow the view's sort order when it maps to a process
+                // field. Otherwise keep pid order from BTreeMap iteration.
+                if let Some(process_sort) = state
+                    .sort_order
+                    .as_ref()
+                    .and_then(cgroup_sort_to_process_sort)
+                {
+                    for procs in map.values_mut() {
+                        sort_queriables(procs, &process_sort, state.reverse);
+                    }
+                }
+                Some(map)
+            };
         let mut rows = Vec::new();
-        self.output_cgroup(&state.get_model(), state, &filtered_set, &mut rows, offset);
+        self.output_cgroup(
+            &state.get_model(),
+            state,
+            &filtered_set,
+            &cgroup_to_procs,
+            &mut rows,
+            offset,
+        );
         rows
     }
 }
@@ -480,5 +612,242 @@ pub mod default_tabs {
             ViewItem::from_default(Net(RxPacketsPerSec)),
             ViewItem::from_default(Net(TxPacketsPerSec)),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use model::ProcessModel;
+    use model::SingleProcessModel;
+
+    use super::*;
+    use crate::cgroup_view::CgroupState;
+
+    fn cgroup_node(
+        name: &str,
+        full_path: &str,
+        depth: u32,
+        children: Vec<CgroupModel>,
+    ) -> CgroupModel {
+        CgroupModel {
+            data: SingleCgroupModel {
+                name: name.to_owned(),
+                full_path: full_path.to_owned(),
+                depth,
+                ..Default::default()
+            },
+            children: children.into_iter().collect(),
+            count: 1,
+            recreate_flag: false,
+        }
+    }
+
+    fn fake_cgroup_model() -> CgroupModel {
+        cgroup_node(
+            "<root>",
+            "",
+            0,
+            vec![
+                cgroup_node(
+                    "child1",
+                    "/child1",
+                    1,
+                    vec![cgroup_node("nested", "/child1/nested", 2, vec![])],
+                ),
+                cgroup_node("other", "/other", 1, vec![]),
+            ],
+        )
+    }
+
+    fn fake_process(pid: i32, comm: &str, cmdline: &str, cgroup: &str) -> SingleProcessModel {
+        SingleProcessModel {
+            pid: Some(pid),
+            comm: Some(comm.to_owned()),
+            cmdline: Some(cmdline.to_owned()),
+            cgroup: Some(cgroup.to_owned()),
+            ..Default::default()
+        }
+    }
+
+    fn fake_process_model() -> ProcessModel {
+        let mut processes = BTreeMap::new();
+        processes.insert(
+            100,
+            fake_process(100, "proc_a", "/bin/proc_a --flag", "/child1"),
+        );
+        processes.insert(
+            200,
+            fake_process(200, "proc_b", "/bin/proc_b", "/child1/nested"),
+        );
+        processes.insert(300, fake_process(300, "proc_root", "/bin/proc_root", "/"));
+        ProcessModel { processes }
+    }
+
+    fn fake_state() -> CgroupState {
+        CgroupState {
+            model: Arc::new(Mutex::new(fake_cgroup_model())),
+            process_model: Arc::new(Mutex::new(fake_process_model())),
+            ..Default::default()
+        }
+    }
+
+    fn tab() -> CgroupTab {
+        CgroupTab::new(default_tabs::get_general_items(), &RenderConfig::default())
+    }
+
+    fn keys(rows: &[(StyledString, String)]) -> Vec<&str> {
+        rows.iter().map(|(_row, key)| key.as_str()).collect()
+    }
+
+    #[test]
+    fn test_get_rows_no_expansion() {
+        let rows = tab().get_rows(&fake_state(), None);
+        assert_eq!(keys(&rows), vec!["", "/child1", "/child1/nested", "/other"]);
+        assert!(
+            rows.iter()
+                .all(|(row, _key)| !row.source().contains("proc_")),
+            "no process rows should render without expansion"
+        );
+    }
+
+    #[test]
+    fn test_get_rows_expanded_procs() {
+        let mut state = fake_state();
+        state.expanded_procs_cgroups.insert("/child1".to_owned());
+        let rows = tab().get_rows(&state, None);
+
+        // Process row shows up directly under its cgroup, keyed by the
+        // cgroup's full path
+        assert_eq!(
+            keys(&rows),
+            vec!["", "/child1", "/child1", "/child1/nested", "/other"]
+        );
+        let proc_row = &rows[2].0;
+        let source = proc_row.source();
+        assert!(source.contains("proc_a"), "got: {}", source);
+        assert!(source.contains("100"), "got: {}", source);
+        assert!(source.contains("--flag"), "got: {}", source);
+        // Processes of the nested cgroup are not pulled into the parent
+        assert!(
+            !rows
+                .iter()
+                .any(|(row, _key)| row.source().contains("proc_b")),
+            "expansion should only show the cgroup's own processes"
+        );
+        assert!(
+            proc_row.spans().all(|span| span.attr.color.front
+                == cursive::theme::ColorType::Color(cursive::theme::Color::Light(
+                    cursive::theme::BaseColor::Blue
+                ))),
+            "process rows should render in blue"
+        );
+    }
+
+    #[test]
+    fn test_expanded_procs_collapse_wins() {
+        let mut state = fake_state();
+        state.expanded_procs_cgroups.insert("/child1".to_owned());
+        state
+            .collapsed_cgroups
+            .lock()
+            .unwrap()
+            .insert("/child1".to_owned());
+        let rows = tab().get_rows(&state, None);
+        assert_eq!(keys(&rows), vec!["", "/child1", "/other"]);
+        assert!(
+            !rows
+                .iter()
+                .any(|(row, _key)| row.source().contains("proc_a")),
+            "collapsed cgroups should not show process rows"
+        );
+    }
+
+    #[test]
+    fn test_expanded_procs_root_normalization() {
+        let mut state = fake_state();
+        // Root's full_path is "" while its processes report cgroup "/"
+        state.expanded_procs_cgroups.insert("".to_owned());
+        let rows = tab().get_rows(&state, None);
+        assert_eq!(
+            keys(&rows),
+            vec!["", "", "/child1", "/child1/nested", "/other"]
+        );
+        assert!(rows[1].0.source().contains("proc_root"));
+    }
+
+    #[test]
+    fn test_toggle_procs_for_selected_cgroup() {
+        let mut state = fake_state();
+        state.current_selected_cgroup = "/child1".to_owned();
+        state.toggle_procs_for_selected_cgroup();
+        assert!(state.expanded_procs_cgroups.contains("/child1"));
+        state.toggle_procs_for_selected_cgroup();
+        assert!(state.expanded_procs_cgroups.is_empty());
+
+        // Keys that don't resolve to a live cgroup are ignored
+        for key in ["[RECREATED] /child1", "/nonexistent"] {
+            state.current_selected_cgroup = key.to_owned();
+            state.toggle_procs_for_selected_cgroup();
+            assert!(state.expanded_procs_cgroups.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_expanded_procs_sort_mapping() {
+        let mut state = fake_state();
+        {
+            let mut process_model = state.process_model.lock().unwrap();
+            for (pid, usage_pct) in [(100, 5.0), (101, 90.0)] {
+                let mut process =
+                    fake_process(pid, &format!("proc_{}", pid), "/bin/proc", "/child1");
+                process.cpu = Some(model::ProcessCpuModel {
+                    usage_pct: Some(usage_pct),
+                    ..Default::default()
+                });
+                process_model.processes.insert(pid, process);
+            }
+        }
+        state.expanded_procs_cgroups.insert("/child1".to_owned());
+        let pos = |rows: &[(StyledString, String)], needle: &str| {
+            rows.iter()
+                .position(|(row, _key)| row.source().contains(needle))
+                .unwrap_or_else(|| panic!("row {} not found", needle))
+        };
+
+        // Without a sort order, process rows follow pid order
+        let rows = tab().get_rows(&state, None);
+        assert!(pos(&rows, "proc_100") < pos(&rows, "proc_101"));
+
+        // A cgroup sort with a process equivalent applies to process rows
+        state.sort_order = Some(SingleCgroupModelFieldId::Cpu(
+            model::CgroupCpuModelFieldId::UsagePct,
+        ));
+        state.reverse = true;
+        let rows = tab().get_rows(&state, None);
+        assert!(pos(&rows, "proc_101") < pos(&rows, "proc_100"));
+
+        // A sort with no process equivalent falls back to pid order
+        state.sort_order = Some(SingleCgroupModelFieldId::Name);
+        let rows = tab().get_rows(&state, None);
+        assert!(pos(&rows, "proc_100") < pos(&rows, "proc_101"));
+    }
+
+    #[test]
+    fn test_expanded_procs_with_filter() {
+        let mut state = fake_state();
+        state.expanded_procs_cgroups.insert("/child1".to_owned());
+        state.filter_info = Some((SingleCgroupModelFieldId::Name, "other".to_owned()));
+        let rows = tab().get_rows(&state, None);
+        assert_eq!(keys(&rows), vec!["", "/other"]);
+        assert!(
+            !rows
+                .iter()
+                .any(|(row, _key)| row.source().contains("proc_a")),
+            "filtered-out cgroups should not show process rows"
+        );
     }
 }

--- a/below/view/src/cgroup_view.rs
+++ b/below/view/src/cgroup_view.rs
@@ -28,6 +28,7 @@ use model::CgroupCpuModelFieldId;
 use model::CgroupIoModelFieldId;
 use model::CgroupMemoryModelFieldId;
 use model::CgroupModel;
+use model::ProcessModel;
 use model::Queriable;
 use model::SingleCgroupModelFieldId;
 
@@ -58,6 +59,10 @@ pub struct CgroupState {
     pub reverse: bool,
     pub model: Arc<Mutex<CgroupModel>>,
     pub collapse_all_top_level_cgroup: bool,
+    // Cgroups whose processes are shown inline as child rows
+    pub expanded_procs_cgroups: HashSet<String>,
+    // Process model for rendering the processes of expanded cgroups
+    pub process_model: Arc<Mutex<ProcessModel>>,
 }
 
 impl StateCommon for CgroupState {
@@ -156,6 +161,8 @@ impl StateCommon for CgroupState {
             reverse: false,
             model,
             collapse_all_top_level_cgroup: false,
+            expanded_procs_cgroups: HashSet::new(),
+            process_model: Default::default(),
         }
     }
 }
@@ -201,6 +208,18 @@ impl CgroupState {
                 .lock()
                 .unwrap()
                 .extend(cur.children.iter().map(|c| &c.data.full_path).cloned());
+        }
+    }
+
+    pub fn toggle_procs_for_selected_cgroup(&mut self) {
+        let cgroup = self.current_selected_cgroup.clone();
+        // Keys that don't resolve to a live cgroup (e.g. "[RECREATED] ..." rows)
+        // can't be expanded
+        if self.get_model().get_by_path_str(&cgroup).is_none() {
+            return;
+        }
+        if !self.expanded_procs_cgroups.remove(&cgroup) {
+            self.expanded_procs_cgroups.insert(cgroup);
         }
     }
 }
@@ -326,6 +345,7 @@ impl CgroupView {
             },
         );
         let mut cgroup_state = CgroupState::new(user_data.cgroup.clone());
+        cgroup_state.process_model = user_data.process.clone();
         if user_data.viewrc.collapse_cgroups == Some(true) {
             cgroup_state.collapse_all_top_level_cgroup = true;
         }
@@ -378,6 +398,14 @@ impl CgroupView {
                 .lock()
                 .unwrap()
                 .collapse_selected_cgroup_children();
+            view.refresh(c);
+        })
+        .on_event('e', |c| {
+            let mut view = Self::get_cgroup_view(c);
+            view.state
+                .lock()
+                .unwrap()
+                .toggle_procs_for_selected_cgroup();
             view.refresh(c);
         })
         .with_name(Self::get_view_name())

--- a/below/view/src/help_menu.rs
+++ b/below/view/src/help_menu.rs
@@ -200,6 +200,7 @@ fn fill_reserved(v: &mut LinearLayout) {
         " <End>          - scroll to end of primary display\n",
         " <Enter>        - collapse/expand cgroup tree, submit command if command palette activated\n",
         " '='            - collapse immediate children of selected cgroup\n",
+        " 'e'            - toggle showing processes of the selected cgroup (cgroup view only)\n",
         " <Ctrl>-r       - refresh the screen",
         " 'P'            - sort by pid (process view only)\n",
         " 'N'            - sort by name (process view only)\n",

--- a/below/view/src/help_menu.rs
+++ b/below/view/src/help_menu.rs
@@ -200,7 +200,7 @@ fn fill_reserved(v: &mut LinearLayout) {
         " <End>          - scroll to end of primary display\n",
         " <Enter>        - collapse/expand cgroup tree, submit command if command palette activated\n",
         " '='            - collapse immediate children of selected cgroup\n",
-        " 'e'            - toggle showing processes of the selected cgroup (cgroup view only)\n",
+        " 'e'            - show or hide the processes running inside the selected cgroup (cgroup view only)\n",
         " <Ctrl>-r       - refresh the screen",
         " 'P'            - sort by pid (process view only)\n",
         " 'N'            - sort by name (process view only)\n",


### PR DESCRIPTION
Fixes #8238

In the cgroup view, pressing `e` on the selected cgroup now displays its member processes as indented child rows, so you can see what is actually running in a cgroup without zooming away from the tree. The rows are rendered in blue to stand out from cgroup rows and show comm, pid, state, CPU usage, resident memory, and the full command line, which is usually enough to tell at a glance what a busy scope is doing.

<img width="2710" height="1414" alt="below_expand_demo" src="https://github.com/user-attachments/assets/5b65df3c-dd58-484b-b186-93ffb07829a7" />


A few notes:

- Expansion is sticky and per cgroup (rather than flooding the screen by displaying all processes). Collapsing a cgroup hides its process rows until you reopen it.
- Only processes directly in the expanded cgroup are listed. Processes of descendant cgroups stay under their own cgroups, so nothing shows up twice.
- Each process row remembers which cgroup it belongs to. So, if your cursor is on a process row and you press `z`, below understands you mean "show me the processes of the cgroup this thing lives in" and takes you there. Same idea for `Enter`/`=`/`e`: they act as if you had pressed them on the cgroup that owns the process.
-  If the view is sorted (for example, by CPU), the process rows try to follow the same rule. Sorting cgroups by CPU also sorts the processes inside each cgroup by CPU, so the hungriest one is on top (that is why `yes` appears above `bash` in the screenshot). Some sorts only make sense for cgroups and have no process version. In those cases, the processes are listed in ascending order of their pid.
- Processes are indexed by cgroup path once per refresh (and only when at least one cgroup is expanded), so row generation stays O(cgroups + processes). If nothing is expanded, there is no extra work.

The process columns intentionally do not line up with the cgroup column titles above them (the fields differ, so they cannot). Keeping the rows compact and colored seemed better than mirroring the full process view, where the command line ends up far off-screen.

Testing: the row generation this feature touches lives in `below/view/src/cgroup_tabs.rs`, which previously had no unit tests. This PR adds seven, covering expansion rendering, exact-match scoping, collapse interaction, root path normalization, sort mapping, filter interaction, and the toggle guard.
