### PR TITLE
procfs: Swallow InvalidFileFormat when parsing ns/pid, fixing invocation as unprivileged user

### DIFF
--- a/below/procfs/src/lib.rs
+++ b/below/procfs/src/lib.rs
@@ -1104,6 +1104,7 @@ impl ProcReader {
                 Err(Error::IoError(_, ref e))
                     if e.raw_os_error()
                         .is_some_and(|ec| ec == ENOENT || ec == ESRCH || ec == EACCES) => {}
+                Err(Error::InvalidFileFormat(_)) => {}
                 res => pidinfo.pid_ns = Some(res?),
             }
 


### PR DESCRIPTION
Summary:

When running below as an unprivileged user, reading /proc/1/ns/pid may yield an empty string due to permissions, resulting in an InvalidFileFormat error instead of an IoError. Fix below invocations as unprivileged user by ignoring InvalidFileFormat in read_all_pid_info_from_path (similar to EACCES) so that execution does not abort early when encountering an inaccessible process namespace.